### PR TITLE
Include fontawesome-webfont.woff2 in pip package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,3 +8,4 @@ recursive-include sphinx_rtd_theme *.js
 recursive-include sphinx_rtd_theme *.svg
 recursive-include sphinx_rtd_theme *.ttf
 recursive-include sphinx_rtd_theme *.woff
+recursive-include sphinx_rtd_theme *.woff2


### PR DESCRIPTION
`fontawesome-webfont.woff2` was added in f22bfd2, but it was never added to the white list for the pip package. Without the woff2 file, modern browsers are required to fall back to the older woff format which has a slightly larger file size.