### PR TITLE
Configurable width

### DIFF
--- a/sass/_theme_layout.sass
+++ b/sass/_theme_layout.sass
@@ -311,7 +311,7 @@
 .wy-nav-content
   padding: $gutter $gutter * 2
   height: 100%
-  max-width: 800px
+  max-width: $content-width
   margin: auto
 
 .wy-body-mask

--- a/sass/_theme_variables.sass
+++ b/sass/_theme_variables.sass
@@ -6,7 +6,7 @@ $font-awesome-dir:                    "../fonts/"
 $static-img:                          "../img/"
 $mathjax-color:                       $text-color
 
-$content-width:                       800px
+$content-width:                       {{ theme_content-width }}
 
 $headerlink-color:                    $text-color
 

--- a/sass/_theme_variables.sass
+++ b/sass/_theme_variables.sass
@@ -6,7 +6,7 @@ $font-awesome-dir:                    "../fonts/"
 $static-img:                          "../img/"
 $mathjax-color:                       $text-color
 
-$content-width:                       {{ theme_content-width }}
+$content-width:                       {{ theme_content_width }}
 
 $headerlink-color:                    $text-color
 

--- a/sass/_theme_variables.sass
+++ b/sass/_theme_variables.sass
@@ -6,6 +6,8 @@ $font-awesome-dir:                    "../fonts/"
 $static-img:                          "../img/"
 $mathjax-color:                       $text-color
 
+$content-width:                       800px
+
 $headerlink-color:                    $text-color
 
 // Code colors

--- a/sphinx_rtd_theme/theme.conf
+++ b/sphinx_rtd_theme/theme.conf
@@ -3,6 +3,7 @@ inherit = basic
 stylesheet = css/theme.css
 
 [options]
+content-width = 800px
 typekit_id = hiw1hhg
 analytics_id =
 sticky_navigation = False

--- a/sphinx_rtd_theme/theme.conf
+++ b/sphinx_rtd_theme/theme.conf
@@ -3,7 +3,7 @@ inherit = basic
 stylesheet = css/theme.css
 
 [options]
-content-width = 800px
+content_width = 800px
 typekit_id = hiw1hhg
 analytics_id =
 sticky_navigation = False


### PR DESCRIPTION
This was in hopes to fix https://github.com/rtfd/sphinx_rtd_theme/issues/295

However, because we are using sass I cannot figure out how to make a link between `theme.conf` and the sass file.

Other themes do this but they are using plain css for example https://github.com/sphinx-doc/sphinx/blob/master/sphinx/themes/classic/static/classic.css_t

Not really know what to do here. Maybe using scss would work or something like https://github.com/jrief/django-sass-processor but not really sure here and would like some help/feedback