### PR TITLE
Set the before & after width of the nav buttons to 100%

### DIFF
--- a/sass/_theme_layout.sass
+++ b/sass/_theme_layout.sass
@@ -336,6 +336,8 @@ footer
     color: $footer-color
 
 .rst-footer-buttons
+  &:before, &:after
+    width: 100%
   +clearfix
 
 .rst-breadcrumbs-buttons


### PR DESCRIPTION
This solves the issue where the buttons might appear in weird locations when the is a trailing element aligned to one side (e.g. an image).

See below for an example of this broken result:

![broken page](https://cloud.githubusercontent.com/assets/15183467/23570630/0b77a2e6-0033-11e7-848c-8d08b84fa1ae.PNG)