### PR TITLE
Use lighter color for sidebar captions

### DIFF
--- a/sass/_theme_layout.sass
+++ b/sass/_theme_layout.sass
@@ -35,7 +35,7 @@
     font-weight: bold
     text-transform: uppercase
     font-size: 80%
-    color: $menu-color
+    color: $menu-dark
     white-space: nowrap
 
   ul

--- a/sass/_theme_variables.sass
+++ b/sass/_theme_variables.sass
@@ -17,7 +17,7 @@ $class-color:                         $blue
 $method-color:                        $gray
 
 // GUI label color
-$guilabel-color:                         $blue
+$guilabel-color:                      $blue
 
 // Footer colors
 $footer-color:                        $gray-light
@@ -27,7 +27,7 @@ $menu-vertical-background-color:      $section-background-color
 
 // Menu text colors
 $menu-color:                          $gray
-$menu-dark:                           lighten($menu-color,15%) !default
+$menu-dark:                           lighten($menu-color,10%) !default
 $menu-medium:                         lighten($menu-color,25%) !default
 $menu-light:                          lighten($menu-color,45%) !default
 $menu-lighter:                        lighten($menu-color,60%) !default


### PR DESCRIPTION
Before:

![captionafter](https://cloud.githubusercontent.com/assets/15183467/23880107/dd5ed184-0827-11e7-8ada-2ee4b0e26976.PNG)

After:

![captionbefore](https://cloud.githubusercontent.com/assets/15183467/23880105/dcb1d966-0827-11e7-9670-c3a426032140.PNG)
