### PR TITLE
Add language to the JS output variable

### DIFF
--- a/sphinx_rtd_theme/layout.html
+++ b/sphinx_rtd_theme/layout.html
@@ -181,6 +181,7 @@
         var DOCUMENTATION_OPTIONS = {
             URL_ROOT:'{{ url_root }}',
             VERSION:'{{ release|e }}',
+            LANGUAGE:'{{ language }}',
             COLLAPSE_INDEX:false,
             FILE_SUFFIX:'{{ '' if no_search_suffix else file_suffix }}',
             HAS_SOURCE:  {{ has_source|lower }},


### PR DESCRIPTION
Makes the current language accessible as a JS variable.
Would be nice to have for the version & language switch I'm writing (to avoid the workaround of extracting it from the url).