### PR TITLE
Remove unused theme options

### DIFF
--- a/sphinx_rtd_theme/theme.conf
+++ b/sphinx_rtd_theme/theme.conf
@@ -3,8 +3,6 @@ inherit = basic
 stylesheet = css/theme.css
 
 [options]
-typekit_id = hiw1hhg
-analytics_id =
 sticky_navigation = False
 logo_only =
 collapse_navigation = False


### PR DESCRIPTION
These have been here since the initial commit but AFAIK they are unused.