### PR TITLE
Reflect language in lang attribute.

### DIFF
--- a/sphinx_rtd_theme/layout.html
+++ b/sphinx_rtd_theme/layout.html
@@ -8,8 +8,8 @@
 {%- endif %}
 
 <!DOCTYPE html>
-<!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
-<!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
+<!--[if IE 8]><html class="no-js lt-ie9" lang="{%if language == None %}en{% else %}{{ language }}{% endif %}" > <![endif]-->
+<!--[if gt IE 8]><!--> <html class="no-js" lang="{%if language == None %}en{% else %}{{ language }}{% endif %}" > <!--<![endif]-->
 <head>
   <meta charset="utf-8">
   {{ metatags }}

--- a/sphinx_rtd_theme/layout.html
+++ b/sphinx_rtd_theme/layout.html
@@ -6,10 +6,11 @@
 {%- else %}
   {%- set titlesuffix = "" %}
 {%- endif %}
+{%- set lang_attr = 'en' if language == None else (language | replace('_', '-')) %}
 
 <!DOCTYPE html>
-<!--[if IE 8]><html class="no-js lt-ie9" lang="{%if language == None %}en{% else %}{{ language }}{% endif %}" > <![endif]-->
-<!--[if gt IE 8]><!--> <html class="no-js" lang="{%if language == None %}en{% else %}{{ language }}{% endif %}" > <!--<![endif]-->
+<!--[if IE 8]><html class="no-js lt-ie9" lang="{{ lang_attr }}" > <![endif]-->
+<!--[if gt IE 8]><!--> <html class="no-js" lang="{{ lang_attr }}" > <!--<![endif]-->
 <head>
   <meta charset="utf-8">
   {{ metatags }}


### PR DESCRIPTION
The basic Sphinx templates check `language` and use it to set `<html lang>`, so I think it makes sense to do this here. A few sites like Blender documentation have multiple languages, and at the moment Google will return results from all the languages even when asking for English results. With a proper `lang` I think it will be able to return appropriate results.

I'm not a Jinja ninja so let me know if there's a more concise way to do the if/else. I've built the demo site to check that it works (defaults to `en`, and changes when `-A language=fr` is passed)