### PR TITLE
Added `.admonition` to the CSS

### DIFF
--- a/sass/_theme_rst.sass
+++ b/sass/_theme_rst.sass
@@ -50,7 +50,7 @@
   .literal-block, pre.literal-block
     @extend .codeblock
   // These are the various note pullouts that sphinx applies
-  .note, .attention, .caution, .danger, .error, .hint, .important, .tip, .warning, .seealso, .admonition-todo
+  .note, .attention, .caution, .danger, .error, .hint, .important, .tip, .warning, .seealso, .admonition-todo, .admonition
     @extend .wy-alert
     .last
       margin-bottom: 0
@@ -119,7 +119,7 @@
         display: inline-block
     &:hover .headerlink
       display: inline-block
-  
+
   .centered
     text-align: center
 


### PR DESCRIPTION
FIxes #461 

Now generic admonitions are styled too.

# Proof of concept

## Broken version
<img width="742" alt="screenshot 2017-09-14 00 18 36" src="https://user-images.githubusercontent.com/86222/30439151-4b6269b6-9973-11e7-82d6-875971a67de0.png">

## Fixed version
<img width="727" alt="screenshot 2017-09-14 17 34 59" src="https://user-images.githubusercontent.com/86222/30439176-59a3798e-9973-11e7-8cbf-9aaa7f67db28.png">
