### PR TITLE
Only change current if a matching link is found

### DIFF
--- a/js/theme.js
+++ b/js/theme.js
@@ -108,13 +108,15 @@ function ThemeNav () {
                   // Try again with the closest section entry.
                   link = $('.wy-menu-vertical')
                     .find('[href="#' + closest_section.attr("id") + '"]');
-
                 }
-                $('.wy-menu-vertical li.toctree-l1 li.current')
-                    .removeClass('current');
-                link.closest('li.toctree-l2').addClass('current');
-                link.closest('li.toctree-l3').addClass('current');
-                link.closest('li.toctree-l4').addClass('current');
+                // If we found a matching link then reset current and re-apply
+                // otherwise retain the existing match
+                if (link.length > 0) {
+                    $('.wy-menu-vertical li.toctree-l1 li.current').removeClass('current');
+                    link.closest('li.toctree-l2').addClass('current');
+                    link.closest('li.toctree-l3').addClass('current');
+                    link.closest('li.toctree-l4').addClass('current');
+                }
             }
             catch (err) {
                 console.log("Error expanding nav for anchor", err);


### PR DESCRIPTION
Fix for #397 to only reset `current` style and re-apply if a new candidate link has been found.

Envoy docs have links with unresolved anchors, this fix avoids collapsing the L3/L4 headers if not matching link for the anchor is found.