### PR TITLE
Apply clearfix on breadcrumbs

### DIFF
--- a/sass/_theme_breadcrumbs.sass
+++ b/sass/_theme_breadcrumbs.sass
@@ -1,3 +1,6 @@
+.wy-breadcrumbs
+  +clearfix
+
 .wy-breadcrumbs li
   display: inline-block
   &.wy-breadcrumbs-aside


### PR DESCRIPTION
Fixes #486

Old behaviour: 

 ![long](https://user-images.githubusercontent.com/3284111/33120302-f553f96a-cf71-11e7-80dc-7865897a9061.png)
![long buttons](https://user-images.githubusercontent.com/3284111/33120465-6c8305bc-cf72-11e7-8666-dd170b584dad.png)

New behaviour:
![long-fixed](https://user-images.githubusercontent.com/3284111/33120740-47988384-cf73-11e7-91da-3fc33891a07e.png)
![long buttons-fixed](https://user-images.githubusercontent.com/3284111/33120745-494bb23c-cf73-11e7-9ace-17e9135b6c81.png)
