### PR TITLE
Add option to style external links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,7 +96,8 @@ file of this repository, and can be defined in your project's ``conf.py`` via
         'includehidden': True
         'logo_only':
         'display_version': True
-        'prev_next_buttons_location': bottom
+        'prev_next_buttons_location': bottom,
+        'style_external_links': False
     }
 
 The following options are available:
@@ -107,6 +108,7 @@ The following options are available:
 * ``includehidden`` Specifies if the global toctree includes toctrees marked with the `:hidden:` option
 * ``prev_next_buttons_location`` can take the value ``bottom``, ``top``, ``both`` , or ``None``
   and will display the "Next" and "Previous" buttons accordingly
+* ``style_external_links`` Add an icon next to external links. Defaults to ``False``.
 
 Page-level configuration
 ------------------------

--- a/sass/_theme_rst.sass
+++ b/sass/_theme_rst.sass
@@ -33,13 +33,14 @@
   // Usually it's a good idea to give images some space.
   .section > img,   .section > a > img
     margin-bottom: $base-line-height
-  // Questionable whether this is nice or not. It styles eternal links, but comes with some baggage.
-  // a.reference.external:after
-  //   font-family: FontAwesome
-  //   content: " \f08e "
-  //   color: $text-light
-  //   vertical-align: super
-  //   font-size: 60%
+
+  // Style external links
+  a.reference.external:after
+    font-family: FontAwesome
+    content: " \f08e "
+    color: $text-light
+    vertical-align: super
+    font-size: 60%
 
   // For the most part, its safe to assume that sphinx wants you to use a blockquote as an indent. It gets
   // used in many different ways, so don't assume you can apply some fancy style, just leave it be.

--- a/sass/_theme_rst.sass
+++ b/sass/_theme_rst.sass
@@ -35,7 +35,7 @@
     margin-bottom: $base-line-height
 
   // Style external links
-  a.reference.external:after
+  &.style-external-links a.reference.external:after
     font-family: FontAwesome
     content: "\f08e"
     color: $text-light

--- a/sass/_theme_rst.sass
+++ b/sass/_theme_rst.sass
@@ -37,10 +37,11 @@
   // Style external links
   a.reference.external:after
     font-family: FontAwesome
-    content: " \f08e "
+    content: "\f08e"
     color: $text-light
     vertical-align: super
     font-size: 60%
+    margin: 0 0.2em
 
   // For the most part, its safe to assume that sphinx wants you to use a blockquote as an indent. It gets
   // used in many different ways, so don't assume you can apply some fancy style, just leave it be.

--- a/sphinx_rtd_theme/layout.html
+++ b/sphinx_rtd_theme/layout.html
@@ -159,7 +159,11 @@
 
       {# PAGE CONTENT #}
       <div class="wy-nav-content">
+        {% if (theme_style_external_links == 'True') %}
+        <div class="rst-content style-external-links">
+        {% else %}
         <div class="rst-content">
+        {% endif %}
           {% include "breadcrumbs.html" %}
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
            <div itemprop="articleBody">

--- a/sphinx_rtd_theme/theme.conf
+++ b/sphinx_rtd_theme/theme.conf
@@ -14,3 +14,4 @@ includehidden = True
 logo_only =
 display_version = True
 prev_next_buttons_location = bottom
+style_external_links = False


### PR DESCRIPTION
This re-enables styling of external links if a new theme config option `style_external_links` is set to `True` (defaults to `False` for old, unstyled behavior)

Rendered result:
<img width="350" alt="screen shot 2017-12-05 at 11 01 10" src="https://user-images.githubusercontent.com/3284111/33601159-b03dfd1e-d9ab-11e7-8945-dd4f1933dba8.png">

Fixes #427.

Implementation note: This PR adds a CSS class to a div that contains the main content depending on the theme option. It might have been cleaner to conditionally include the CSS style rule only if the theme option is set, but I couldn't get the templating to apply to CSS.