### PR TITLE
Move DOCUMENTATION_OPTIONS to external JS for purposes of CSP

### DIFF
--- a/js/documentation_options.js
+++ b/js/documentation_options.js
@@ -1,0 +1,9 @@
+var urlParams = new URLSearchParams(window.location.search);
+var DOCUMENTATION_OPTIONS = {
+    URL_ROOT: urlParams.get('URL_ROOT'),
+    VERSION: urlParams.get('VERSION'),
+    COLLAPSE_INDEX: urlParams.get('COLLAPSE_INDEX'),
+    FILE_SUFFIX: urlParams.get('FILE_SUFFIX'),
+    HAS_SOURCE: urlParams.get('HAS_SOURCE'),
+    SOURCELINK_SUFFIX: urlParams.get('SOURCELINK_SUFFIX')
+};

--- a/sphinx_rtd_theme/layout.html
+++ b/sphinx_rtd_theme/layout.html
@@ -184,17 +184,7 @@
 
   {% if not embedded %}
 
-    <script type="text/javascript">
-        var DOCUMENTATION_OPTIONS = {
-            URL_ROOT:'{{ url_root }}',
-            VERSION:'{{ release|e }}',
-            LANGUAGE:'{{ language }}',
-            COLLAPSE_INDEX:false,
-            FILE_SUFFIX:'{{ '' if no_search_suffix else file_suffix }}',
-            HAS_SOURCE:  {{ has_source|lower }},
-            SOURCELINK_SUFFIX: '{{ sourcelink_suffix }}'
-        };
-    </script>
+    <script type="text/javascript" src="{{ pathto('_static/js/documentation_options.js', 1) }}?URL_ROOT={{ url_root }}&VERSION={{ release|e }}&COLLAPSE_INDEX=false&FILE_SUFFIX={{ '' if no_search_suffix else file_suffix }}&HAS_SOURCE={{ has_source|lower }}&SOURCELINK_SUFFIX={{ sourcelink_suffix }}"></script>
     {%- for scriptfile in script_files %}
       <script type="text/javascript" src="{{ pathto(scriptfile, 1) }}"></script>
     {%- endfor %}


### PR DESCRIPTION
Ref: https://github.com/sphinx-doc/sphinx/issues/3620
https://github.com/rtfd/sphinx_rtd_theme/issues/414

Currently the only thing that needs to be fixed for [CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) support is removing this bit of inline javascript. This is probably not the best way to do things, but I'm opening this PR for feedback. Even if it doesn't get approved, suggestions would still be useful so I can use them for my own site.