### PR TITLE
Do not create source map for production builds

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -76,6 +76,7 @@ module.exports = function(grunt) {
       build: {
         options: {
           style: 'compressed',
+          sourcemap: 'none',
           loadPath: ['bower_components/bourbon/dist', 'bower_components/neat/app/assets/stylesheets', 'bower_components/font-awesome/scss', 'bower_components/wyrm/sass']
         },
         files: [{


### PR DESCRIPTION
Source maps are not packaged, which leads to a 404 when opening the developer tools (see #478).

This PR disable the creation of source maps when running grunt build, but keeps them during development.
Fixes #478.