### PR TITLE
Make Gruntfile more foolproof

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -162,6 +162,6 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-browserify');
 
   grunt.registerTask('fonts', ['clean:fonts','copy:fonts']);
-  grunt.registerTask('default', ['exec:bower_update','clean:build','copy:fonts','sass:dev','browserify:dev','exec:build_sphinx','connect','open','watch']);
+  grunt.registerTask('default', ['exec:bower_update','clean','copy:fonts','sass:dev','browserify:dev','exec:build_sphinx','connect','open','watch']);
   grunt.registerTask('build', ['exec:bower_update','clean','copy:fonts','sass:build','browserify:build','exec:build_sphinx']);
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -124,7 +124,7 @@ module.exports = function(grunt) {
       build: ["demo_docs/build"],
       fonts: ["sphinx_rtd_theme/static/fonts"],
       css: ["sphinx_rtd_theme/static/css"],
-      js: ["sphinx_rtd_theme/static/js"]
+      js: ["sphinx_rtd_theme/static/js/*", "!sphinx_rtd_theme/static/js/modernizr.min.js"]
     },
 
     watch: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -162,6 +162,6 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-browserify');
 
   grunt.registerTask('fonts', ['clean:fonts','copy:fonts']);
-  grunt.registerTask('default', ['exec:bower_update','clean:build','sass:dev','browserify:dev','exec:build_sphinx','connect','open','watch']);
-  grunt.registerTask('build', ['exec:bower_update','clean','sass:build','browserify:build','exec:build_sphinx']);
+  grunt.registerTask('default', ['exec:bower_update','clean:build','copy:fonts','sass:dev','browserify:dev','exec:build_sphinx','connect','open','watch']);
+  grunt.registerTask('build', ['exec:bower_update','clean','copy:fonts','sass:build','browserify:build','exec:build_sphinx']);
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -163,5 +163,5 @@ module.exports = function(grunt) {
 
   grunt.registerTask('fonts', ['clean:fonts','copy:fonts']);
   grunt.registerTask('default', ['exec:bower_update','clean:build','sass:dev','browserify:dev','exec:build_sphinx','connect','open','watch']);
-  grunt.registerTask('build', ['exec:bower_update','clean:build','sass:build','browserify:build','exec:build_sphinx']);
+  grunt.registerTask('build', ['exec:bower_update','clean','sass:build','browserify:build','exec:build_sphinx']);
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -122,7 +122,9 @@ module.exports = function(grunt) {
     },
     clean: {
       build: ["demo_docs/build"],
-      fonts: ["sphinx_rtd_theme/static/fonts"]
+      fonts: ["sphinx_rtd_theme/static/fonts"],
+      css: ["sphinx_rtd_theme/static/css"],
+      js: ["sphinx_rtd_theme/static/js"]
     },
 
     watch: {


### PR DESCRIPTION
This should reduce some issues where incorrect files are committed or released:

- Clean all output before building. Prevents outdated/orphaned files from being committed
- Run `copy:fonts` when building. Prevents issues with outdated or missing font files (no need to repeat #506 manually)