### PR TITLE
Always call nav.enable() to make nav collapsing work

### DIFF
--- a/js/theme.js
+++ b/js/theme.js
@@ -15,17 +15,22 @@ function ThemeNav () {
         isRunning: false
     };
 
-    nav.enable = function () {
+    nav.enable = function (withStickyNav) {
         var self = this;
 
-        if (!self.isRunning) {
-            self.isRunning = true;
-            jQuery(function ($) {
-                self.init($);
+        if (self.isRunning) {
+            // Only allow enabling nav logic once
+            return;
+        }
 
-                self.reset();
-                self.win.on('hashchange', self.reset);
+        self.isRunning = true;
+        jQuery(function ($) {
+            self.init($);
 
+            self.reset();
+            self.win.on('hashchange', self.reset);
+
+            if (withStickyNav) {
                 // Set scroll monitor
                 self.win.on('scroll', function () {
                     if (!self.linkScroll) {
@@ -35,18 +40,23 @@ function ThemeNav () {
                         }
                     }
                 });
+            }
 
-                // Set resize monitor
-                self.win.on('resize', function () {
-                    if (!self.winResize) {
-                        self.winResize = true;
-                        requestAnimationFrame(function() { self.onResize(); });
-                    }
-                });
-
-                self.onResize();
+            // Set resize monitor
+            self.win.on('resize', function () {
+                if (!self.winResize) {
+                    self.winResize = true;
+                    requestAnimationFrame(function() { self.onResize(); });
+                }
             });
-        };
+
+            self.onResize();
+        });
+
+    };
+
+    nav.enableSticky = function() {
+        this.enable(true);
     };
 
     nav.init = function ($) {
@@ -176,7 +186,7 @@ function ThemeNav () {
 module.exports.ThemeNav = ThemeNav();
 
 if (typeof(window) != 'undefined') {
-    window.SphinxRtdTheme = { StickyNav: module.exports.ThemeNav };
+    window.SphinxRtdTheme = { Navigation: module.exports.ThemeNav };
 }
 
 

--- a/sphinx_rtd_theme/layout.html
+++ b/sphinx_rtd_theme/layout.html
@@ -209,14 +209,15 @@
     <script type="text/javascript" src="{{ pathto('_static/js/theme.js', 1) }}"></script>
   {% endif %}
 
-  {# STICKY NAVIGATION #}
-  {% if theme_sticky_navigation|tobool %}
   <script type="text/javascript">
       jQuery(function () {
-          SphinxRtdTheme.StickyNav.enable();
+          {% if theme_sticky_navigation|tobool %}
+          SphinxRtdTheme.Navigation.enableSticky();
+          {% else %}
+          SphinxRtdTheme.Navigation.enable();
+          {% endif %}
       });
   </script>
-  {% endif %}
 
   {%- block footer %} {% endblock %}
 


### PR DESCRIPTION
This used to depend on the sticky nav being enabled.
Fixes #481