### PR TITLE
Uglify during build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -111,7 +111,26 @@ module.exports = function(grunt) {
         dest: 'sphinx_rtd_theme/static/js/theme.js'
       }
     },
-
+    uglify: {
+      dist: {
+        options: {
+          sourceMap: false,
+          mangle: {
+            reserved: ['jQuery'] // Leave 'jQuery' identifier unchanged
+          },
+          ie8: true // compliance with IE 6-8 quirks
+        },
+        files: [{
+          expand: true,
+          src: ['sphinx_rtd_theme/static/js/*.js', '!sphinx_rtd_theme/static/js/*.min.js'],
+          dest: 'sphinx_rtd_theme/static/js/',
+          rename: function (dst, src) {
+            // Use unminified file name for minified file
+            return src;
+          }
+        }]
+      }
+    },
     exec: {
       bower_update: {
         cmd: 'bower update'
@@ -162,5 +181,5 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-browserify');
 
   grunt.registerTask('default', ['exec:bower_update','clean','copy:fonts','sass:dev','browserify:dev','exec:build_sphinx','connect','open','watch']);
-  grunt.registerTask('build', ['exec:bower_update','clean','copy:fonts','sass:build','browserify:build','exec:build_sphinx']);
+  grunt.registerTask('build', ['exec:bower_update','clean','copy:fonts','sass:build','browserify:build','uglify','exec:build_sphinx']);
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "grunt-contrib-connect": "^1.0.2",
     "grunt-contrib-copy": "~1.0.0",
     "grunt-contrib-sass": "~1.0.0",
+    "grunt-contrib-uglify": "^3.3.0",
     "grunt-contrib-watch": "~1.0.0",
     "grunt-exec": "~1.0.1",
     "grunt-open": "0.2.3",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "grunt-contrib-connect": "^1.0.2",
     "grunt-contrib-copy": "~1.0.0",
     "grunt-contrib-sass": "~1.0.0",
-    "grunt-contrib-uglify": "^3.3.0",
+    "grunt-contrib-uglify": "~3.3.0",
     "grunt-contrib-watch": "~1.0.0",
     "grunt-exec": "~1.0.1",
     "grunt-open": "0.2.3",


### PR DESCRIPTION
Adds an extra uglify task when running `grunt build`.
The symbol `jQuery` is left as-is so other code may use this identifier if needed.
IE6-8 compatibility is turned on just in case.

Fixes #527 
