### PR TITLE
Do not warn about using external images

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,6 +39,9 @@ extensions = [
     'sphinxcontrib.httpdomain',
 ]
 
+# Do not warn about external images (status badges in README.rst)
+suppress_warnings = ['image.nonlocal_uri']
+
 # Math
 mathjax_path = "http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"
 


### PR DESCRIPTION
Now that README.rst contains status badges, Sphinx will warn that these are from an external source.
This PR disables those warnings (this only applies to the docs for the theme, not any other docs built using the theme)

```
>> README.rst:None: WARNING: nonlocal image URI found: https://img.shields.io/pypi/v/sphinx_rtd_theme.svg
>> README.rst:None: WARNING: nonlocal image URI found: https://travis-ci.org/rtfd/sphinx_rtd_theme.svg?branch=master
>> README.rst:None: WARNING: nonlocal image URI found: https://img.shields.io/pypi/l/sphinx_rtd_theme.svg
>> README.rst:None: WARNING: nonlocal image URI found: https://readthedocs.org/projects/sphinx-rtd-theme/badge/?version=latest
```