### PR TITLE
Remove mathjax_path override

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,9 +42,6 @@ extensions = [
 # Do not warn about external images (status badges in README.rst)
 suppress_warnings = ['image.nonlocal_uri']
 
-# Math
-mathjax_path = "http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"
-
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,9 +39,6 @@ extensions = [
     'sphinxcontrib.httpdomain',
 ]
 
-# Math
-mathjax_path = "http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"
-
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 


### PR DESCRIPTION
The demo docs uses the MathJax CDN, which is (being) shut down: https://www.mathjax.org/cdn-shutting-down/. This causes a JS warning in the console and will in future break math display in the demo docs.
This PR removes the override of `mathjax_path` to use whatever Sphinx is using. Sphinx has been using a different CDN (Cloudflare) since 1.5.5.

Note that RTD is currently using Sphinx 1.5.3, which uses the same CDN as the theme used before this PR. Merging this PR should not change the behaviour on RTD, but keeping MathJax functioning correctly on RTD will require updating to Sphinx 1.5.5+ ([release notes](http://www.sphinx-doc.org/en/stable/changes.html#release-1-5-5-released-apr-03-2017)), or alternatively adding the override back into the theme, but with the Cloudflare CDN.