### PR TITLE
Readme sections in sidebar

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,8 +24,9 @@
 Read the Docs Sphinx Theme
 **************************
 
-.. contents:: 
+.. contents::
    :backlinks: none
+   :local:
 
 View a working demo_ over on readthedocs.org_.
 

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -1,0 +1,1 @@
+.. include:: ../README.rst

--- a/docs/demo/index.rst
+++ b/docs/demo/index.rst
@@ -1,12 +1,9 @@
-Read the Docs Theme Demo
-************************
+Theme Demo
+**********
 
 These documents are used to test and stress test the Read the Docs Theme.
 
 :Last Reviewed: 2017-3-15
-
-Contents
-========
 
 .. toctree::
     :maxdepth: 3

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,6 @@
-Content
-=======
+##########################
+Read the Docs Sphinx Theme
+##########################
 
 .. toctree::
    :caption: Theme

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,11 +3,9 @@ Read the Docs Sphinx Theme
 ##########################
 
 .. toctree::
-   :caption: Theme
 
    README
 
 .. toctree::
-   :caption: Demo
 
    demo/index

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,4 +7,8 @@ Read the Docs Sphinx Theme
    README
    demo/index
 
+.. raw:: html
 
+    <script>
+    window.location = 'README.html';
+    </script>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,7 +5,6 @@ Read the Docs Sphinx Theme
 .. toctree::
 
    README
-
-.. toctree::
-
    demo/index
+
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,11 +1,10 @@
-
-.. include:: ../README.rst
-
 Content
 =======
 
 .. toctree::
    :caption: Theme
+
+   README
 
 .. toctree::
    :caption: Demo


### PR DESCRIPTION
This PR makes the README sections appear in the navbar.
It uses an intermediate file to indirectly include the README (`toctree` does not allow including files that are in a parent directory).
The location of the README remains unchanged (so it renders nicely on GitHub).

A JavaScript redirect is used to send viewers directly to the README page, rather than displaying a page containing only the table of contents.

Fixes #523.