### PR TITLE
Allow versions popup to scroll

### DIFF
--- a/sass/_theme_badge.sass
+++ b/sass/_theme_badge.sass
@@ -6,7 +6,6 @@
   width: $nav-desktop-width
   color: $section-background-color
   background: darken($menu-background-color, 8%)
-  border-top: solid 10px $menu-background-color
   font-family: $base-font-family
   z-index: $z-index-tray
   a

--- a/sass/_theme_badge.sass
+++ b/sass/_theme_badge.sass
@@ -35,7 +35,7 @@
       background-color: $yellow
       color: $black
   &.shift-up
-    height: 100%
+    max-height: 100%
   &.shift-up .rst-other-versions
     display: block
   .rst-other-versions

--- a/sass/_theme_badge.sass
+++ b/sass/_theme_badge.sass
@@ -2,6 +2,7 @@
   position: fixed
   bottom: 0
   left: 0
+  overflow-y: scroll
   width: $nav-desktop-width
   color: $section-background-color
   background: darken($menu-background-color, 8%)
@@ -34,6 +35,8 @@
     &.rst-active-old-version
       background-color: $yellow
       color: $black
+  &.shift-up
+    height: 100%
   &.shift-up .rst-other-versions
     display: block
   .rst-other-versions


### PR DESCRIPTION
@Blendify can you please verify this? I have no project on RTD with enough versions to check if this fixes #575.
I've successfully tested against your url with chrome devtools though.

Note that I have removed the top border from that section, since it looked bad when the versions popup was fully expanded. It also fixes something I've always found odd. If this is desired, we can put it back in.

Before:
![border above rst-versions](https://user-images.githubusercontent.com/3284111/36196633-aaed5c4e-1171-11e8-945e-9a9848066737.png)
After:
![no border](https://user-images.githubusercontent.com/3284111/36196634-ab0cfefa-1171-11e8-9500-d2c82bbb0319.png)
