### PR TITLE
use id to find the future current sidebar item

### DIFF
--- a/js/theme.js
+++ b/js/theme.js
@@ -117,19 +117,19 @@ function ThemeNav () {
         var anchor = encodeURI(window.location.hash) || '#';
 
         try {
-            var link = $('.wy-menu-vertical')
-                .find('[href="' + anchor + '"]');
-            // If we didn't find a link, it may be because we clicked on
-            // something that is not in the sidebar (eg: when using
-            // sphinxcontrib.httpdomain it generates headerlinks but those
-            // aren't picked up and placed in the toctree). So let's find
-            // the closest header in the document and try with that one.
+            var vmenu = $('.wy-menu-vertical');
+            var link = vmenu.find('[href="' + anchor + '"]');
             if (link.length === 0) {
-              var doc_link = $('.document a[href="' + anchor + '"]');
-              var closest_section = doc_link.closest('div.section');
-              // Try again with the closest section entry.
-              link = $('.wy-menu-vertical')
-                .find('[href="#' + closest_section.attr("id") + '"]');
+                // this link was not found in the sidebar.
+                // Find associated id element, then its closest section
+                // in the document and try with that one.
+                var id_elt = $('.document [id="' + anchor.substring(1) + '"]');
+                var closest_section = id_elt.closest('div.section');
+                link = vmenu.find('[href="#' + closest_section.attr("id") + '"]');
+                if (link.length === 0) {
+                    // still not found in the sidebar. fall back to main section
+                    link = vmenu.find('[href="#"]');
+                }
             }
             // If we found a matching link then reset current and re-apply
             // otherwise retain the existing match


### PR DESCRIPTION
Fixes #583

- find the referenced 'id element' first, then the closest section
- if no association found in the sidebar, fallback to #
- reword comments