### PR TITLE
Add color to all th borders

### DIFF
--- a/sass/_theme_rst.sass
+++ b/sass/_theme_rst.sass
@@ -231,6 +231,8 @@
   table.docutils
     @extend .wy-table
     @extend .wy-table-bordered-all
+    th
+      border-color: $table-border-color
     &:not(.field-list)
       @extend .wy-table-striped
   // This table is what gets spit out for auto-generated API stuff. I style it smaller bits of padding.


### PR DESCRIPTION
Wyrm does not define a border color for all table borders, only the ones that it explicitly sets other style rules for (such as border width).
This caused Firefox to use the browser default of black for some `<th>` borders.
Fixes #581.