### PR TITLE
Do not allow selection of line numbers in code blocks

### DIFF
--- a/sass/_theme_rst.sass
+++ b/sass/_theme_rst.sass
@@ -70,6 +70,8 @@
     margin: 0
     padding: $base-line-height / 2 $base-line-height / 2
     font-family: $code-font-family
+    user-select: none
+    pointer-events: none
   div[class^='highlight'] pre
     white-space: pre
     margin: 0


### PR DESCRIPTION
When selecting some text to copy from a code block with line numbers, line numbers can be accidentally selected. Since any place where the code will be pasted will not benefit from having the line numbers present, it's better to make these unselectable.