### PR TITLE
Add bower to dev depends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@
 .ruby-version
 dist/
 bower_components/
-node_modules/
+node_modules
 npm-debug.log
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "sphinx_rtd_theme",
   "version": "0.2.5b2",
   "private": true,
-  "dependencies": {},
+  "dependencies": {
+    "bower": "^1.8.4"
+  },
   "devDependencies": {
     "browserify": "^13.0.0",
     "connect-livereload": "~0.6.0",

--- a/package.json
+++ b/package.json
@@ -2,10 +2,8 @@
   "name": "sphinx_rtd_theme",
   "version": "0.2.5b2",
   "private": true,
-  "dependencies": {
-    "bower": "^1.8.4"
-  },
   "devDependencies": {
+    "bower": "^1.8.4",
     "browserify": "^13.0.0",
     "connect-livereload": "~0.6.0",
     "grunt": "~1.0.1",


### PR DESCRIPTION
All of our dependencies should be specified, we don't rely on global installs
anywhere with node modules.