### PR TITLE
Set collapse_navigation to true

### DIFF
--- a/sphinx_rtd_theme/theme.conf
+++ b/sphinx_rtd_theme/theme.conf
@@ -6,7 +6,7 @@ pygments_style = default
 [options]
 canonical_url =
 analytics_id =
-collapse_navigation = False
+collapse_navigation = True
 sticky_navigation = True
 navigation_depth = 4
 includehidden = True


### PR DESCRIPTION
This matches 0.2.4 behavior. Although it might not be desired behavior, the behavior of setting this to true can result in file size to explode and build times also.

This was caused by bf9faa98f0cb64aa3536528231ad9a3f48e819ac which effectly switched the logic of `collapse_navigation`