### PR TITLE
Fix centered tables

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,17 @@ Changelog
 master
 ======
 
+New Features
+-------------
+
+Fixes
+-----
+
+* Fix table centering (#599)
+
+Other Changes
+--------------
+
 v0.3.0
 ======
 

--- a/sass/_theme_rst.sass
+++ b/sass/_theme_rst.sass
@@ -143,7 +143,9 @@
     margin: 0px $base-line-height $base-line-height 0px
   .align-center
     margin: auto
-    display: block
+    // Do not override display:table for tables
+    &:not(table)
+      display: block
   .toctree-wrapper p.caption
     @extend h2
 


### PR DESCRIPTION
Centered elements get `display: block` which does not work with tables. This PR excepts tables, so they will still use `display: table` and center properly
Fixes #599.