### PR TITLE
Write minified file to correct location

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -123,7 +123,6 @@ module.exports = function(grunt) {
         files: [{
           expand: true,
           src: ['sphinx_rtd_theme/static/js/*.js', '!sphinx_rtd_theme/static/js/*.min.js'],
-          dest: 'sphinx_rtd_theme/static/js/',
           rename: function (dst, src) {
             // Use unminified file name for minified file
             return src;


### PR DESCRIPTION
The minification from #531 only produced a minified js file for the demo doc build, not when building for distribution. This PR also minifies for the latter situation.