### PR TITLE
Make code block line emphasis span entire line

### DIFF
--- a/sass/_theme_rst.sass
+++ b/sass/_theme_rst.sass
@@ -79,6 +79,11 @@
     font-family: $code-font-family
     display: block
     overflow: auto
+    & .hll
+      // Line emphasis spans full width
+      display: block
+      margin: 0 -1 * $base-line-height / 2
+      padding: 0 $base-line-height / 2
   pre.literal-block, div[class^='highlight'] pre, .linenodiv pre
     font-size: 12px
     line-height: normal


### PR DESCRIPTION
This makes line emphasis look similar to 0.2.4 and before. Original styling was [set by Wyrm pygments add-on](https://github.com/snide/wyrm/blob/master/sass/wyrm_addons/pygments/_pygments_light.sass#L1-L5), but was lost when we switched to stock pygments.

![new](https://user-images.githubusercontent.com/3284111/38606311-f26ef976-3d75-11e8-9ab5-15dde5c1fb70.png)

Fixes #605.