### PR TITLE
Add a requirements.txt file

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -23,7 +23,7 @@ Set up your environment
 
    .. code:: bash
 
-       pip install sphinx sphinxcontrib-httpdomain
+       pip install -r requirements.txt
 
 #. Install sass.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Sphinx
+sphinxcontrib-httpdomain


### PR DESCRIPTION
This simply puts the requirements for building the theme into a `requirements.txt` file. This makes it more obvious what is required.