### PR TITLE
Remove default value for `vcs_pageview_mode`

### DIFF
--- a/sphinx_rtd_theme/theme.conf
+++ b/sphinx_rtd_theme/theme.conf
@@ -15,4 +15,3 @@ logo_only =
 display_version = True
 prev_next_buttons_location = bottom
 style_external_links = False
-vcs_pageview_mode =


### PR DESCRIPTION
Fix https://github.com/rtfd/readthedocs.org/issues/3994

This variable is used on the template and evaluated to give a default value.

According to http://jinja.pocoo.org/docs/2.10/templates/#default default only works if the variable is undefined, or passing true as the second argument to evaluate to false. Otherwise, the variable is `''` so, it's defined and it's displayed.