### PR TITLE
Fix for mkdocs version selector

### DIFF
--- a/sass/_theme_badge.sass
+++ b/sass/_theme_badge.sass
@@ -35,6 +35,7 @@
       background-color: $yellow
       color: $black
   &.shift-up
+    height: auto
     max-height: 100%
   &.shift-up .rst-other-versions
     display: block


### PR DESCRIPTION
In newer versions of MkDocs, [they released](https://github.com/mkdocs/mkdocs/pull/1157/files#diff-7f35da080bb5f31f2a3f5a8249aca6feR37) a change that makes the version selector not pop up when it is on readthedocs.org. While I realize this is the sphinx theme and mkdocs is not sphinx, this CSS here (which becomes https://media.readthedocs.org/css/badge_only.css) gets used on both mkdocs and sphinx.

You can see this in action here: https://mkdocs.readthedocs.io/en/stable/