### PR TITLE
Increase definition list spacing

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,21 @@
 Changelog
 *********
 
+master
+======
+
+New Features
+-------------
+
+Fixes
+-----
+
+* Fix small styling issues
+
+Other Changes
+--------------
+
+
 v0.3.1
 ======
 

--- a/sass/_theme_rst.sass
+++ b/sass/_theme_rst.sass
@@ -288,6 +288,7 @@
     // rST seems to want dds to be treated as the browser would, indented.
     dd
       margin: 0  0 $base-line-height / 2 $base-line-height
+      line-height: $base-line-height
   // This is what Sphinx spits out for it's autodocs. Depending upon what language the person is referencing
   // these things usually have a class of "method" or "class" or something similar, but really who knows.
   // Sphinx doesn't give me a generic class on these, so unfortunately I have to apply it to the root dl.

--- a/sass/_theme_rst.sass
+++ b/sass/_theme_rst.sass
@@ -282,6 +282,7 @@
     margin-bottom: $base-line-height
     dt
       font-weight: bold
+      margin-bottom: $base-line-height / 2
     // Most of the content within these dls are one liners, so I halve the normal margins.
     p, table, ul, ol
       margin-bottom: $base-line-height / 2 !important


### PR DESCRIPTION
RST source:

```rst
one paragraph
    that is really long yes really check it out omg my fingers are getting tired from all this typing but i have to keep going come on i know you can do it

two paragraphs
    the first paragraph of this list item is really long yes really check it out omg my fingers are getting tired from all this typing but i have to keep going come on i know you can do it

    second paragraph in this list item
```

Output before PR:

![before](https://user-images.githubusercontent.com/3284111/39699131-220c6e7a-51f8-11e8-8c06-5b028accc12b.png)
Note the difference in spacing between the first and second line of the first paragraph. This is because a single paragraph is not wrappend in a `<p>` element (which contains the line-height definition)

Output with PR:

![after](https://user-images.githubusercontent.com/3284111/39699132-222092d8-51f8-11e8-8613-a933aa0db486.png)

This also increase the whitespace between a term and the definition, which I think it looks more balanced.