### PR TITLE
Give line blocks the same line height as regular text

### DIFF
--- a/sass/_theme_rst.sass
+++ b/sass/_theme_rst.sass
@@ -132,6 +132,7 @@
   .line-block
     margin-left: 0px
     margin-bottom: $base-line-height
+    line-height: $base-line-height
   .line-block .line-block
     margin-left: $base-line-height
     margin-bottom: 0px


### PR DESCRIPTION
Before:

![before](https://user-images.githubusercontent.com/3284111/39700113-4bbf6192-51fc-11e8-9ae5-a3af4f757c53.png)


After:

![after](https://user-images.githubusercontent.com/3284111/39700114-4bd6ed1c-51fc-11e8-9b45-e895547d0a91.png)
