### PR TITLE
Prevent extra whitespace at bottom of some table cells

### DIFF
--- a/sass/_theme_rst.sass
+++ b/sass/_theme_rst.sass
@@ -246,6 +246,9 @@
       border-color: $table-border-color
     &:not(.field-list)
       @extend .wy-table-striped
+    // Remove bottom margin for the last element (and it's last child)
+    td .last, td .last :last-child
+      margin-bottom: 0
   // This table is what gets spit out for auto-generated API stuff. I style it smaller bits of padding.
   table.field-list
     @extend .wy-table


### PR DESCRIPTION
Apologies for the image dimensions, I didn't feel like chopping them up into smaller images.

Many HTML elements in the theme have a `margin-bottom` to ensure proper vertical whitespace between them and any following content. This is also the case if such an element is in a table cell, but the bottom margin makes the cell higher than it should be. This is not the case for text, because wyrm removes the `margin-bottom` to make it look better:

![before](https://user-images.githubusercontent.com/3284111/39764119-3561607e-52df-11e8-9590-a6d1e77ef367.png)

This PR removes the `margin-bottom` from any element which is "last" in a table cell:

![after](https://user-images.githubusercontent.com/3284111/39764120-3583574c-52df-11e8-9c49-2c16bc3df78a.png)

