### PR TITLE
Accessibility improvements to the left nav

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,14 @@
 Changelog
 *********
 
+Master
+======
+
+Fixes
+-----
+
+* Color accessibility improvements on the left navigation
+
 v0.3.1
 ======
 

--- a/sass/_theme_layout.sass
+++ b/sass/_theme_layout.sass
@@ -24,7 +24,9 @@
     padding: 0 $base-font-size
 
 .wy-menu-vertical
+  color: $menu-medium
   width: $nav-desktop-width
+
   header, p.caption
     height: $base-font-size * 2
     display: inline-block
@@ -35,7 +37,6 @@
     font-weight: bold
     text-transform: uppercase
     font-size: 80%
-    color: $menu-dark
     white-space: nowrap
 
   ul
@@ -97,6 +98,8 @@
     border-top: solid 1px darken($menu-vertical-background-color, 20%)
 
   // This is the on state for pages beyond second level
+  li.toctree-l2 a, li.toctree-l3 a, li.toctree-l4 a
+    color: $menu-link-color
   li.toctree-l1.current li.toctree-l2, li.toctree-l2.current li.toctree-l3
     > ul
       display: none

--- a/sass/_theme_variables.sass
+++ b/sass/_theme_variables.sass
@@ -32,7 +32,7 @@ $menu-vertical-background-color:      $section-background-color
 // Menu text colors
 $menu-color:                          $gray
 $menu-dark:                           lighten($menu-color,10%) !default
-$menu-medium:                         lighten($menu-color,25%) !default
+$menu-medium:                         lighten($menu-color,30%) !default
 $menu-light:                          lighten($menu-color,45%) !default
 $menu-lighter:                        lighten($menu-color,60%) !default
 
@@ -40,7 +40,7 @@ $menu-lighter:                        lighten($menu-color,60%) !default
 $menu-link-color:                     $text-color
 $menu-link-dark:                      $text-dark
 $menu-link-medium:                    $text-medium
-$menu-link-light:                     $text-light
+$menu-link-light:                     $text-lighter
 $menu-link-active:                    $white
 
 // Navigation colors


### PR DESCRIPTION
This makes a few color changes to the left navigation with an eye toward improved accessibility. Specifically, I looked at the colors on our existing theme and they [don't have enough contrast](http://jxnblk.com/colorable/demos/text/?background=%23343131&foreground=%236f6f6f). The headings are the worst offenders but some of the links aren't fantastic.

<img width="610" alt="screen shot 2018-05-14 at 3 28 40 pm" src="https://user-images.githubusercontent.com/185043/40019095-3fa914d0-578c-11e8-8e64-870f9839a33b.png">

Ping @mahmoud