### PR TITLE
Declare the main entry point of the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "sphinx_rtd_theme",
+  "main": "js/theme.js",
   "version": "0.4.0",
   "private": true,
   "devDependencies": {


### PR DESCRIPTION
This is needed after installing with `npm` to use `require`.