### PR TITLE
Adjust codeblock lineheight

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,8 @@ New Features
 Fixes
 -----
 
+* Line height adjustments for Liberation Mono (#656)
+
 
 Other Changes
 --------------

--- a/sass/_theme_rst.sass
+++ b/sass/_theme_rst.sass
@@ -93,7 +93,7 @@
   pre.literal-block, div[class^='highlight'] pre, .linenodiv pre
     font-family: $code-font-family
     font-size: 12px
-    line-height: normal
+    line-height: 1.4
 
   @media print
     .codeblock, div[class^='highlight'], div[class^='highlight'] pre


### PR DESCRIPTION
This PR sets the line-height for code blocks and literals to something other than `normal` so that it is more consistent (Liberation Mono used to look compressed). I've increased the line-height to `1.4` (from `1.2`) because it looks a little less cramped and better matches the line-height in the rest of the theme IMHO.
Comments on the exact value to choose are appreciated.

Menlo on Chrome macOS, line-height `normal` or `1.2` | Menlo on Chrome macOS, line-height `1.4`
--- | ---
![osx-menlo-1 2](https://user-images.githubusercontent.com/3284111/42265204-296d661c-7f73-11e8-9f60-64c94cf330c9.png) | ![osx-menlo-1 4](https://user-images.githubusercontent.com/3284111/42265203-29581460-7f73-11e8-8eb5-65f4bb218c77.png)

Liberation Mono on Chromium Xubuntu, line-height `normal` as in #656 | Liberation Mono on Chromium Xubuntu, line-height `1.2` | Liberation Mono on Chromium Xubuntu, line-height `.4`
--- | --- | ---
![xubuntu-liberation-normal](https://user-images.githubusercontent.com/3284111/42265202-293eaa98-7f73-11e8-86fe-fee54f5d5dd2.png) | ![xubuntu-liberation-1 2](https://user-images.githubusercontent.com/3284111/42265201-29278e80-7f73-11e8-8c9a-cb7c4568f39c.png) | ![xubuntu-liberation-1 4](https://user-images.githubusercontent.com/3284111/42265200-290ebc84-7f73-11e8-8851-fc8867080589.png)

Fixes #656 