### PR TITLE
Avoid printing dot when copyright holder already ends with dot

### DIFF
--- a/sphinx_rtd_theme/footer.html
+++ b/sphinx_rtd_theme/footer.html
@@ -16,9 +16,9 @@
     <p>
     {%- if show_copyright %}
       {%- if hasdoc('copyright') %}
-        {% trans path=pathto('copyright'), copyright=copyright|e %}&copy; <a href="{{ path }}">Copyright</a> {{ copyright }}.{% endtrans %}
+        {% trans path=pathto('copyright'), copyright=copyright|e %}&copy; <a href="{{ path }}">Copyright</a> {{ copyright }}{% endtrans %}
       {%- else %}
-        {% trans copyright=copyright|e %}&copy; Copyright {{ copyright }}.{% endtrans %}
+        {% trans copyright=copyright|e %}&copy; Copyright {{ copyright }}{% endtrans %}
       {%- endif %}
     {%- endif %}
 


### PR DESCRIPTION
When you set `copyright = "My Company, Inc."` in `conf.py` for your documentation and generate html from it, the copyright is rendered like this:

    © Copyright 2018, My Company, Inc..

Which is bad, we ideally want to have only one dot at the end.

It can't be workarounded by setting `copyright = "My Company, Inc"`, because then man pages get rendered wrong, e.g.

    AUTHOR
           My Company, Inc.

    COPYRIGHT
           2018, My Company, Inc

Therefore I am proposing this pull request. It is quite hard to fix it properly because it needs to be done per-theme and therefore it can bring some inconsistencies. If there is a better way to fix it, please let me know.