### PR TITLE
Set base font size on <html>

### DIFF
--- a/sass/_theme_layout.sass
+++ b/sass/_theme_layout.sass
@@ -1,3 +1,7 @@
+// Set uniform (but not relative) base font size
+html
+  font-size: $base-font-size
+
 .wy-affix
   position: fixed
   top: $gutter


### PR DESCRIPTION
Most elements have their font size set to `$base-font-size` (14px), but some elements like lists and text in the sidebar inherit a font-size of 100% from `<html>`. This causes inconsistencies when viewed on a browser that sets a custom font size != 14px.

This PR sets the font size of `<html>` to `$base-font-size` so that everything has a uniform size, regardless of browser settings. It _does not_ respect the browsers font size, which is bad for accessibility, but it does work with scaling by the browser.

Fixes #125