### PR TITLE
Nicer styles for <kbd>

### DIFF
--- a/sass/_theme_rst.sass
+++ b/sass/_theme_rst.sass
@@ -400,6 +400,7 @@
     background-color: lighten($text-light, 20%)
     border: 1px solid darken($text-light, 5%)
     border-radius: $base-line-height / 6
+    box-shadow: grey 0px $base-line-height / 12
     padding: $base-line-height / 10 $base-line-height / 4
     margin: auto 0
   .versionmodified

--- a/sass/_theme_rst.sass
+++ b/sass/_theme_rst.sass
@@ -397,7 +397,7 @@
   kbd, .kbd
     color: inherit
     font-size: 80%
-    background-color: lighten($text-light, 20%)
+    background-color: lighten($text-light, 30%)
     border: 1px solid darken($text-light, 5%)
     border-radius: $base-line-height / 6
     box-shadow: grey 0px $base-line-height / 12

--- a/sass/_theme_rst.sass
+++ b/sass/_theme_rst.sass
@@ -394,6 +394,13 @@
     border-radius: $base-line-height / 6
     padding: $base-line-height / 10 $base-line-height / 4
     margin: auto $base-line-height / 12
+  kbd, .kbd
+    color: inherit
+    background-color: lighten($text-light, 20%)
+    border: 1px solid darken($text-light, 5%)
+    border-radius: $base-line-height / 6
+    padding: $base-line-height / 10 $base-line-height / 4
+    margin: auto $base-line-height / 12
   .versionmodified
     font-style: italic
 

--- a/sass/_theme_rst.sass
+++ b/sass/_theme_rst.sass
@@ -396,6 +396,7 @@
     margin: auto $base-line-height / 12
   kbd, .kbd
     color: inherit
+    font-size: 80%
     background-color: lighten($text-light, 20%)
     border: 1px solid darken($text-light, 5%)
     border-radius: $base-line-height / 6

--- a/sass/_theme_rst.sass
+++ b/sass/_theme_rst.sass
@@ -393,7 +393,7 @@
     font-weight: 700
     border-radius: $base-line-height / 6
     padding: $base-line-height / 10 $base-line-height / 4
-    margin: auto $base-line-height / 12
+    margin: auto 0
   kbd, .kbd
     color: inherit
     font-size: 80%
@@ -401,7 +401,7 @@
     border: 1px solid darken($text-light, 5%)
     border-radius: $base-line-height / 6
     padding: $base-line-height / 10 $base-line-height / 4
-    margin: auto $base-line-height / 12
+    margin: auto 0
   .versionmodified
     font-style: italic
 


### PR DESCRIPTION
Fixes #669 

Style:
![literal](https://cloud.githubusercontent.com/assets/15183467/24159963/f22cf0c2-0e36-11e7-8e58-d2842145c37e.PNG)