### PR TITLE
 CSS: Restrict center-alignment to nested <p> in "math" class 

### DIFF
--- a/sass/_theme_mathjax.sass
+++ b/sass/_theme_mathjax.sass
@@ -1,5 +1,5 @@
 span[id*='MathJax-Span']
   color: $mathjax-color
 
-.math
+.math p
   text-align: center


### PR DESCRIPTION
This is how the built-in Sphinx themes do it:

https://github.com/sphinx-doc/sphinx/blob/eb44c73b81ff4e603d9452018d145ff3c204f71f/sphinx/themes/basic/static/basic.css_t#L642-L644

I hope this is actually correct SASS ...

In case you are wondering, one example where the unrestricted centering of the `math` class has unintended consequences is here: https://nbsphinx.readthedocs.io/en/latest/code-cells.html#Math.