### PR TITLE
Style code block captions

### DIFF
--- a/sass/_theme_rst.sass
+++ b/sass/_theme_rst.sass
@@ -95,6 +95,13 @@
     font-size: 12px
     line-height: 1.4
 
+  .code-block-caption
+    font-style: italic
+    font-size: 85%
+    line-height: 1
+    padding: 1em 0
+    text-align: center
+
   @media print
     .codeblock, div[class^='highlight'], div[class^='highlight'] pre
       white-space: pre-wrap

--- a/sass/_theme_rst.sass
+++ b/sass/_theme_rst.sass
@@ -172,7 +172,7 @@
     @extend h2
 
   // This is the #href that shows up on hover. Sphinx's is terrible so I hack it away.
-  h1, h2, h3, h4, h5, h6, dl dt, p.caption, table > caption, .code-block-caption
+  h1, h2, h3, h4, h5, h6, dl dt, p.caption, table > caption
     .headerlink
       visibility: hidden
       font-size: 14px

--- a/sass/_theme_rst.sass
+++ b/sass/_theme_rst.sass
@@ -165,7 +165,7 @@
     @extend h2
 
   // This is the #href that shows up on hover. Sphinx's is terrible so I hack it away.
-  h1, h2, h3, h4, h5, h6, dl dt, p.caption, table > caption
+  h1, h2, h3, h4, h5, h6, dl dt, p.caption, table > caption, .code-block-caption
     .headerlink
       visibility: hidden
       font-size: 14px


### PR DESCRIPTION
This PR styles the caption of code blocks and literal blocks in the same way as table captions (above item that is captioned, italic, centered, 85% size):

<img width="506" alt="centered code caption" src="https://user-images.githubusercontent.com/3284111/47113330-00ac1500-d259-11e8-9bfe-75c9d42cfad6.png">

Note that this is different from the way figure captions are styled at the moment (left-aligned, below figure, 100% size). The closest we can come (because we can't move the caption below the code block) is to just make it italic:

<img width="265" alt="left-aligned code caption" src="https://user-images.githubusercontent.com/3284111/47113383-32bd7700-d259-11e8-9486-0e0b04f93fe4.png">

Fixes #292. Originally also styled the link displayed on hover, this was split into #690 so we can keep the more contentious changes confined to this PR.