### PR TITLE
Style caption link for code and literal blocks

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,23 @@
 Changelog
 *********
 
+master
+======
+
+:Date: TBD
+
+New Features
+-------------
+
+Fixes
+-----
+
+* Style caption link for code and literal blocks
+
+Other Changes
+--------------
+
+
 v0.4.2
 ======
 

--- a/sass/_theme_rst.sass
+++ b/sass/_theme_rst.sass
@@ -165,7 +165,7 @@
     @extend h2
 
   // This is the #href that shows up on hover. Sphinx's is terrible so I hack it away.
-  h1, h2, h3, h4, h5, h6, dl dt, p.caption, table > caption
+  h1, h2, h3, h4, h5, h6, dl dt, p.caption, table > caption, .code-block-caption
     .headerlink
       visibility: hidden
       font-size: 14px


### PR DESCRIPTION
This PR makes the permalink next to code blocks and literal blocks behave the same as the permalink next to headers, images etc.

![caption permalink](https://user-images.githubusercontent.com/3284111/47113724-0b1ade80-d25a-11e8-87e0-a4728104ea8a.gif)

This previously was part of #689, but but was split of into this PR which should not need much discussion.
Reported in #292 