### PR TITLE
Fix inconsistent font size and line height for autodoc "raises" and "returns"

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,23 @@
 Changelog
 *********
 
+master
+======
+
+:Date: TBD
+
+New Features
+-------------
+
+Fixes
+-----
+
+* Fix inconsistent font size and line height for autodoc "raises" and "returns" (#267)
+
+Other Changes
+--------------
+
+
 v0.4.2
 ======
 

--- a/sass/_theme_rst.sass
+++ b/sass/_theme_rst.sass
@@ -263,6 +263,9 @@
     border: none
     td
       border: none
+      p
+        font-size: inherit
+        line-height: inherit
     td > strong
       display: inline-block
     .field-name


### PR DESCRIPTION
Fixes #267 