### PR TITLE
Setup.py references fonts dir plural

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         '*.html',
         'static/css/*.css',
         'static/js/*.js',
-        'static/font/*.*'
+        'static/fonts/*.*'
     ]},
     include_package_data=True,
     # See http://www.sphinx-doc.org/en/stable/theming.html#distribute-your-theme-as-a-python-package


### PR DESCRIPTION
The fonts are in `static/fonts`, but setup.py has been installing
`static/font`. That didn't seem to work for me. This changes setup.py to
match the actual directory.