### PR TITLE
Fix a SASS typo

### DIFF
--- a/sass/_theme_rst.sass
+++ b/sass/_theme_rst.sass
@@ -111,7 +111,7 @@
     @extend .wy-alert
     // These block elements are unsuitable for having floating objects next
     // to them
-    clear: both;
+    clear: both
     .last
       margin-bottom: 0
   .admonition-title


### PR DESCRIPTION
#723 introduced a typo in the SASS which caused the docs not to build. We should probably have CI test that the SASS generates correctly.