### PR TITLE
Fix accessibility of sidebar nav

### DIFF
--- a/sass/_theme_variables.sass
+++ b/sass/_theme_variables.sass
@@ -51,7 +51,7 @@ $nav-link-color:                      $blue
 $nav-link-color-visited:              $purple
 $nav-link-color-hover:                lighten($nav-link-color, 6%) !default
 $nav-link-color-alt:                  hsl(33, 100%, 51%)
-$nav-caption:                         desaturate($blue, 15%)
+$nav-caption:                         lighten($blue, 15%)
 
 // Sidebar colors
 $sidebar-background-color:            $table-stripe-color


### PR DESCRIPTION
Lightening blue results in the color `#55A5D9` which passes AA accessibility on a background of `#343131`.

Fixes #732